### PR TITLE
Pin test requirements

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
-pytest
-pytest-cov
-pytest-timeout
+pytest==5.4.1
+pytest-cov==2.8.1
+pytest-timeout==1.3.4


### PR DESCRIPTION
- It's important to pin our test requirements to not have builds failing randomly when a requirement is updated. We need to make the decision to update consciously.