### PR TITLE
Install typing_extensions regardless of Python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pillow
 pyramid
 pyramid_jinja2
-typing_extensions; python_version < "3.6"
+typing_extensions


### PR DESCRIPTION
From https://mypy.readthedocs.io/en/stable/more_types.html#typeddict:

> Unless you are on Python 3.8 or newer (where TypedDict is available in standard library typing module) you need to install typing_extensions using pip to use TypedDict: